### PR TITLE
Cope with multiple interfaces with the same LL address.

### DIFF
--- a/src/auth.c
+++ b/src/auth.c
@@ -409,7 +409,10 @@ size_t answer_auth(struct dns_header *header, char *limit, size_t qlen, time_t n
 		peer_addr->in.sin_port = 0;
 #ifdef HAVE_IPV6
 	      else
-		peer_addr->in6.sin6_port = 0; 
+		{
+		  peer_addr->in6.sin6_port = 0; 
+		  peer_addr->in6.sin6_scope_id = 0;
+		}
 #endif
 	      
 	      for (peers = daemon->auth_peers; peers; peers = peers->next)

--- a/src/util.c
+++ b/src/util.c
@@ -274,6 +274,7 @@ int sockaddr_isequal(union mysockaddr *s1, union mysockaddr *s2)
 #ifdef HAVE_IPV6      
       if (s1->sa.sa_family == AF_INET6 &&
 	  s1->in6.sin6_port == s2->in6.sin6_port &&
+	  s1->in6.sin6_scope_id == s2->in6.sin6_scope_id &&
 	  IN6_ARE_ADDR_EQUAL(&s1->in6.sin6_addr, &s2->in6.sin6_addr))
 	return 1;
 #endif


### PR DESCRIPTION
This PR brings forward a commit that will land upstream in 2.73 that breaks DHCPv6 when multiple interfaces have the same link-local address. Given that we do exactly that in Calico, this means that DHCPv6 currently doesn't work in Calico.

The hope was that the new release would land pretty rapidly, but sadly it has not. In the short term, we'll backport this change to the 2.72 branch.

I've not volunteered it to any other branch, let me know if we need it in other releases. @matthewdupre is most likely to be useful here, as our RHEL czar.
